### PR TITLE
Add sprite to physics calculations

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -15,7 +15,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "1.0.16",
+        "target": "1.2.6",
         "targetId": "arcade"
     },
     "supportedTargets": [

--- a/text.ts
+++ b/text.ts
@@ -114,6 +114,7 @@ namespace textsprite {
         fg: number = 1,
     ): TextSprite {
         const sprite = new TextSprite(text, bg, fg, 8, 0, 0, 0);
+        game.currentScene().physicsEngine.addSprite(sprite);
         return sprite;
     }
 }


### PR DESCRIPTION
include the created sprite in physics calculations like: https://github.com/microsoft/pxt-common-packages/blob/master/libs/game/sprites.ts#L40

by default sprites are just shown on the screen, not included in the current physics. This is because they historically were also used for ui elements e.g. info score / etc. That job has basically been taken by https://github.com/microsoft/pxt-common-packages/blob/master/libs/game/renderable.ts#L3, but I'm not sure I'd say moving it feels right / generally I'd say the sprite factory / `sprites.create` should probably be responsible for adding to physics *and* scene sprites instead of the constructor, but that'd be a breaking change